### PR TITLE
Add storage blob owner to mi on externalsharing prod

### DIFF
--- a/components/ado-infra/managed_identities.tf
+++ b/components/ado-infra/managed_identities.tf
@@ -86,6 +86,13 @@ data "azurerm_storage_account" "mi_datasharelanding_storage_account" {
   resource_group_name = "mi-${var.env}-rg"
 }
 
+data "azurerm_storage_account" "mi_externalsharing_storage_account" {
+  count = var.env == "prod" ? 1 : 0
+
+  name                = "miexternalsharing${var.env}"
+  resource_group_name = "mi-${var.env}-rg"
+}
+
 ## assigning permissions for SS Pipeline Agents Managed Identity for MI/SDP apps
 resource "azurerm_role_assignment" "mi_landing_contributor" {
   count = var.env == "sbox" || var.env == "ptl" || var.env == "ptlsbox" ? 0 : 1
@@ -150,5 +157,13 @@ resource "azurerm_role_assignment" "aks_mi_datasharelanding_contributor" {
 
   scope                = data.azurerm_storage_account.mi_datasharelanding_storage_account[count.index].id
   role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.azure-devops-mi.principal_id
+}
+
+resource "azurerm_role_assignment" "mi_externalsharing_contributor" {
+  count = var.env == "prod" ? 1 : 0
+
+  scope                = data.azurerm_storage_account.mi_externalsharing_storage_account[count.index].id
+  role_definition_name = "Storage Blob Data Owner"
   principal_id         = azurerm_user_assigned_identity.azure-devops-mi.principal_id
 }

--- a/components/ado-infra/provider.tf
+++ b/components/ado-infra/provider.tf
@@ -13,7 +13,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.2.0"
+  required_version = "~> 1.4.0"
 }
 
 


### PR DESCRIPTION
### Jira link

See [DTSPO-28044](https://tools.hmcts.net/jira/browse/DTSPO-28044)

### Change description

Add blob storage owner to MI to allow team to set write only permissions on the `dwp` container via powershell script in pipeline
See script [here](https://github.com/hmcts/mi-shared-infrastructure/blob/e3b4b73ad7833f0b25d1b83bcf43243ef1789e9c/azure-pipelines.yml#L232)

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
